### PR TITLE
Migrate to GNOME 48

### DIFF
--- a/cursor.js
+++ b/cursor.js
@@ -4,7 +4,7 @@ import Clutter from 'gi://Clutter';
 
 export default class Cursor {
     constructor() {
-		this._tracker = global.backend.get_cursor_tracker(global.display);
+        this._tracker = global.backend.get_cursor_tracker(global.display);
     }
 
     get hot() {

--- a/cursor.js
+++ b/cursor.js
@@ -1,11 +1,10 @@
 'use strict';
 
 import Clutter from 'gi://Clutter';
-import Meta from 'gi://Meta';
 
 export default class Cursor {
     constructor() {
-        this._tracker = Meta.CursorTracker.get_for_display(global.display);
+		this._tracker = global.backend.get_cursor_tracker(global.display);
     }
 
     get hot() {

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "name": "Wiggle",
   "shell-version": [
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/mechtifs/wiggle",
   "uuid": "wiggle@mechtifs",


### PR DESCRIPTION
For more details see [https://gjs.guide/extensions/upgrading/gnome-shell-48.html#meta](https://gjs.guide/extensions/upgrading/gnome-shell-48.html#meta)

Tested:
- Custom cursor Icon works (only with absolute path, idk how it was in previous versions)
- Effects Duration
- Triggers
- Intervals

Closes #16 